### PR TITLE
Fix ComponentWithUseReducer

### DIFF
--- a/chapter_01/07_usereducer_init.js
+++ b/chapter_01/07_usereducer_init.js
@@ -1,6 +1,6 @@
 const init = (count) => ({ count })
 
-const reducer = (prev, delta) => prev + delta
+const reducer = (prev, delta) => ({ ...prev, count: prev.count + delta })
 
 const ComponentWithUseReducer = ({ initialCount }) => {
   const [state, dispatch] = useReducer(
@@ -10,7 +10,7 @@ const ComponentWithUseReducer = ({ initialCount }) => {
   );
   return (
     <div>
-      {state}
+      {state.count}
       <button onClick={() => dispatch(1)}>+1</button>
     </div>
   );


### PR DESCRIPTION
`state` is an object, as shown by the init function `const init = (count) => ({ count })`

This will throw an error if you include `{state}` in a React component directly - instead, count should be accessed via the object property.

Similarly, the reducer should take in to account that the state is an object rather than a single value.

Alternatively, the init function should be changed or removed so that it does not turn the state in to an object.