### PR TITLE
Using action atoms - fix code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ With the following software and hardware list you can run all code files present
   ```
  * Page 22 (code snippet 2, line 2): **const reducer = (prev, delta) => prev + delta** Should be **const reducer = (prev, delta) => ({ ...prev, count: prev.count + delta })**
  * Page 23 (code snippet 1, line 3): **{state}** Should be **{state.count}**
+ * Page 163 (code snippet 2 ,line 3):  **const incrementCountAtom(** _should be_ **const incrementCountAtom = atom(**
   
 
 ## Get to Know the Author

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ With the following software and hardware list you can run all code files present
   ```
  * Page 22 (code snippet 2, line 2): **const reducer = (prev, delta) => prev + delta** Should be **const reducer = (prev, delta) => ({ ...prev, count: prev.count + delta })**
  * Page 23 (code snippet 1, line 3): **{state}** Should be **{state.count}**
- * Page 163 (code snippet 2 ,line 3):  **const incrementCountAtom(** _should be_ **const incrementCountAtom = atom(**
+ * Page 163 (code snippet 2 ,line 3):  **const incrementCountAtom(** Should be **const incrementCountAtom = atom(**
   
 
 ## Get to Know the Author


### PR DESCRIPTION
Fix code example for incrementCountAtom. I don't see this code in this repo so just adding as a note.