### PR TITLE
Fix errata

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ With the following software and hardware list you can run all code files present
  * Page 37 (code snippet 3, line 14): **console.log(container1.addBase(2)); // shows "12"** Should be **console.log(container1.addBase(2)); // shows "3"**.
  * Page 14 (code snippet 1, line 3): **onClick={() => { state.count = 1; setState(state); }** Should be **onClick={() => { state.count = 1; setState(state); }}**.
  * Page 21 (code snippet 2, line 2): **typeof action === 'function' ? action(prev): prev;** Should be **typeof action === 'function' ? action(prev): action;**.
- * Page 21 (code snippet 1, line 7): **return [state, dispatch];** Should be 
+ * Page 23 (code snippet 1, line 14): **return [state, dispatch];** Should be 
   ```
   return (
     <div>


### PR DESCRIPTION
Previous Errata for page 21 added in https://github.com/PacktPublishing/Micro-State-Management-with-React-Hooks/commit/d0c3785e9e10d9ac6086b89e39e8f0e013db7cfa should have been against page 23 - the code referenced on page 21 is a hook and is returning correctly.